### PR TITLE
feat(module): add async config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Installation:
 npm install nest-cloudflare-turnstile --save
 ```
 
-add module to imports array:
+add module to imports array with forRoot method:
 
 ```javascript
 
@@ -39,6 +39,30 @@ add module to imports array:
     tokenResponse: (req) => req.body.turnstileToken // or you can use req.headers.turnstileToken
   })],
 
+```
+
+or with forRootAsync method:
+
+```javascript
+ imports: [
+    TurnstileModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => {
+        const secretKey = config.get<string>(
+          'CLOUDFLARE_TURNSTILE_PRIVATE_KEY',
+        );
+        if (!secretKey) {
+          throw new Error('Missing Cloudflare Turnstile secret');
+        }
+
+        return {
+          secretKey,
+          tokenResponse: (req) => req.body.turnstileToken,
+        };
+      },
+    }),
+  ]
 ```
 
 use `TurnstileCaptcha` decorator on controller:

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -4,7 +4,7 @@ Installation:
 npm install nest-cloudflare-turnstile --save
 ```
 
-add module to imports array:
+add module to imports array with forRoot method:
 
 ```javascript
 
@@ -13,6 +13,30 @@ add module to imports array:
     tokenResponse: (req) => req.body.turnstileToken // or you can use req.headers.turnstileToken
   })],
 
+```
+
+or with forRootAsync method:
+
+```javascript
+ imports: [
+    TurnstileModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => {
+        const secretKey = config.get<string>(
+          'CLOUDFLARE_TURNSTILE_PRIVATE_KEY',
+        );
+        if (!secretKey) {
+          throw new Error('Missing Cloudflare Turnstile secret');
+        }
+
+        return {
+          secretKey,
+          tokenResponse: (req) => req.body.turnstileToken,
+        };
+      },
+    }),
+  ]
 ```
 
 use `TurnstileGuard` guard on controller:

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -1,3 +1,5 @@
 export enum Messages {
-    FAIL = "Failed turnstile verification."
+  FAIL = 'Failed turnstile verification.',
+  MISSING = 'Missing turnstile verification code.',
+  INVALID = 'Invalid turnstile verification code.',
 }

--- a/src/guards/turnstile.guard.ts
+++ b/src/guards/turnstile.guard.ts
@@ -1,22 +1,28 @@
-import { ExecutionContext, CanActivate, Injectable, Inject, InternalServerErrorException } from "@nestjs/common";
-import { TurnstileService } from "../services/turnstile.service";
-import { ITurnstileOptions } from "../interfaces/turnstile";
-import { Messages } from "../constants/messages";
+import {
+  ExecutionContext,
+  CanActivate,
+  Injectable,
+  Inject,
+  BadRequestException,
+} from '@nestjs/common';
+import { TurnstileService } from '../services/turnstile.service';
+import { ITurnstileOptions } from '../interfaces/turnstile';
+import { Messages } from '../constants/messages';
 
 @Injectable()
 export class TurnstileGuard implements CanActivate {
-    constructor(private readonly turnstileService: TurnstileService,
-        @Inject('TurnstileServiceOptions') private readonly options: ITurnstileOptions
-    ) {
-
-    }
-    async canActivate(context: ExecutionContext): Promise<boolean> {
-        const request = context.switchToHttp().getRequest();
-        const responseToken = this.options.tokenResponse(request);
-        if (!responseToken) throw new InternalServerErrorException(Messages.FAIL);
-        const { success } = await this.turnstileService.validateToken(responseToken);
-        if (!success) throw new InternalServerErrorException(Messages.FAIL)
-        else return success;
-    }
+  constructor(
+    private readonly turnstileService: TurnstileService,
+    @Inject('TurnstileServiceOptions')
+    private readonly options: ITurnstileOptions,
+  ) {}
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const responseToken = this.options.tokenResponse(request);
+    if (!responseToken) throw new BadRequestException(Messages.MISSING);
+    const { success } =
+      await this.turnstileService.validateToken(responseToken);
+    if (!success) throw new BadRequestException(Messages.INVALID);
+    else return success;
+  }
 }
-

--- a/src/interfaces/turnstile.ts
+++ b/src/interfaces/turnstile.ts
@@ -1,5 +1,23 @@
+import {
+  Type,
+  DynamicModule,
+  ForwardReference,
+  InjectionToken,
+  OptionalFactoryDependency,
+} from '@nestjs/common';
+
 export interface ITurnstileOptions {
-    secretKey: string;
-    tokenResponse: (req) => string;
-    onError?: (error) => void;
+  secretKey: string;
+  tokenResponse: (req) => string;
+  onError?: (error) => void;
+}
+
+export interface IAsyncTurnstileOptions {
+  imports?: Array<
+    Type<any> | DynamicModule | Promise<DynamicModule> | ForwardReference
+  >;
+  inject?: Array<InjectionToken | OptionalFactoryDependency>;
+  useFactory: (
+    ...args: any[]
+  ) => ITurnstileOptions | Promise<ITurnstileOptions>;
 }

--- a/src/turnstile.module.ts
+++ b/src/turnstile.module.ts
@@ -1,31 +1,49 @@
-import { DynamicModule, Global, Module } from '@nestjs/common';
+import { DynamicModule, Global, Module, Provider } from '@nestjs/common';
 import { TurnstileService } from './services/turnstile.service';
 import { HttpModule } from '@nestjs/axios';
-import { ITurnstileOptions } from './interfaces/turnstile';
+import {
+  IAsyncTurnstileOptions,
+  ITurnstileOptions,
+} from './interfaces/turnstile';
 import { TurnstileGuard } from './guards/turnstile.guard';
+
+const TurnstileServiceOptionsToken = 'TurnstileServiceOptions';
+
+const providers: Provider[] = [TurnstileGuard, TurnstileService];
 
 @Global()
 @Module({})
 export class TurnstileModule {
   public static forRoot(options: ITurnstileOptions): DynamicModule {
-    const TurnstileModuleOptionsProvider = {
-      provide: 'TurnstileServiceOptions',
+    const TurnstileModuleOptionsProvider: Provider = {
+      provide: TurnstileServiceOptionsToken,
       useValue: options,
     };
 
     return {
       module: TurnstileModule,
       imports: [HttpModule],
-      providers: [
-        TurnstileGuard,
-        TurnstileModuleOptionsProvider,
-        TurnstileService,
-      ],
-      exports: [
-        TurnstileGuard,
-        TurnstileModuleOptionsProvider,
-        TurnstileService,
-      ],
+      providers: [...providers, TurnstileModuleOptionsProvider],
+      exports: [...providers, TurnstileModuleOptionsProvider],
+    };
+  }
+
+  public static forRootAsync({
+    imports,
+    inject,
+    useFactory,
+  }: IAsyncTurnstileOptions): DynamicModule {
+    const TurnstileModuleOptionsProvider: Provider = {
+      provide: TurnstileServiceOptionsToken,
+      inject: inject || [],
+      useFactory: useFactory,
+    };
+
+    return {
+      module: TurnstileModule,
+      imports: [...(imports || []), HttpModule],
+      providers: [...providers, TurnstileModuleOptionsProvider],
+      exports: [...providers, TurnstileModuleOptionsProvider],
     };
   }
 }


### PR DESCRIPTION
- Add support for async import with `forRootAsync`.
- I changed the `InternalServerErrorException` to `BadRequestException`, because this is not a server error, but a user request with incorrect or missing data. I also added new error messages.

Example usage:

```ts
import { Module } from '@nestjs/common';
import { ConfigModule, ConfigService } from '@nestjs/config';
import { TurnstileModule } from 'nest-cloudflare-turnstile';

@Module({
  imports: [
    TurnstileModule.forRootAsync({
      imports: [ConfigModule],
      inject: [ConfigService],
      useFactory: (config: ConfigService) => {
        const secretKey = config.get<string>(
          'CLOUDFLARE_TURNSTILE_PRIVATE_KEY',
        );
        if (!secretKey) {
          throw new Error('Missing Cloudflare Turnstile secret');
        }
    
        return {
          secretKey,
          tokenResponse: (req) => req.body.turnstileToken,
        };
      },
    }),
  ]
})
export class AppModule {}
```