### PR TITLE
feat: add exception factory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 # Vitepress
 docs/.vitepress/cache
 docs/.vitepress/dist
+.npmrc

--- a/src/guards/turnstile.guard.ts
+++ b/src/guards/turnstile.guard.ts
@@ -26,10 +26,18 @@ export class TurnstileGuard implements CanActivate {
 
     const request = context.switchToHttp().getRequest();
     const responseToken = this.options.tokenResponse(request);
-    if (!responseToken) throw new BadRequestException(Messages.MISSING);
+    if (!responseToken) {
+      throw this.options.exceptionFactory
+        ? this.options.exceptionFactory('missing')
+        : new BadRequestException(Messages.MISSING);
+    }
     const { success } =
       await this.turnstileService.validateToken(responseToken);
-    if (!success) throw new BadRequestException(Messages.INVALID);
+    if (!success) {
+      throw this.options.exceptionFactory
+        ? this.options.exceptionFactory('invalid')
+        : new BadRequestException(Messages.INVALID);
+    }
     return success;
   }
 }

--- a/src/interfaces/turnstile.ts
+++ b/src/interfaces/turnstile.ts
@@ -11,6 +11,7 @@ export interface ITurnstileOptions {
   tokenResponse: (req) => string;
   onError?: (error) => void;
   skipIf?: boolean;
+  exceptionFactory?: (reason: 'missing' | 'invalid') => Error;
 }
 
 export interface IAsyncTurnstileOptions {


### PR DESCRIPTION
```
TurnstileModule.forRoot({
  secretKey: '...',
  tokenResponse: (req) => req.body.turnstileToken,
  exceptionFactory: (reason) => {
    if (reason === 'missing') return new UnauthorizedException('Captcha token is missing.');
    return new ForbiddenException('Captcha verification failed.');
  },
})
```

If exceptionFactory is not provided, it falls back to the existing BadRequestException behavior.

